### PR TITLE
Add possibility to have hooks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,12 @@ RUN echo "deb http://http.debian.net/debian jessie-backports main" > /etc/apt/so
   && a2enmod fcgid
 
 COPY mapserver.conf /etc/apache2/conf-enabled/
+COPY docker-entrypoint.sh /
 
 ONBUILD COPY mapserver.map /etc/mapserver/
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+# A bug in Docker resets the CMD of the parent image if you set the ENTRYPOINT:
+#   https://github.com/docker/docker/issues/5147
+CMD ["apache2", "-DFOREGROUND"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+#Docker image for mapserver 5.0
+
+Here is a sample Dockerfile for using it:
+```
+FROM camptocamp/mapserver
+MAINTAINER Camptocamp "info@camptocamp.com"
+
+COPY *.map /etc/mapserver/
+COPY *.sh /docker-entrypoint.d/
+```
+
+All the executable files in /docker-entrypoint.d ending with `.sh` will
+be executed by the default entrypoint.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+DIR=/docker-entrypoint.d
+
+if [[ -d "$DIR" ]]
+then
+    /bin/run-parts --regex '\.sh$' "$DIR"
+fi
+
+exec "$@"


### PR DESCRIPTION
For the moment, we can only have hooks run just before apache starts. It
will run all those files:
  /docker-entrypoint.d/*.sh
    
Added a README
