### PR TITLE
Install libgd-dev instead of libgd2-xpm-dev

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 MAINTAINER Camptocamp<info@camptocamp.com>
 
 RUN apt-get -y update && \
-    LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get install -y bison flex python-lxml libfribidi-dev swig cmake librsvg2-dev colordiff libpq-dev libpng-dev libjpeg-dev libgif-dev libgeos-dev libgd-dev libfreetype6-dev libfcgi-dev libcurl4-gnutls-dev libcairo2-dev libgdal-dev libproj-dev libxml2-dev libxslt1-dev python-dev php-dev libexempi-dev lcov lftp libgdal-dev ninja-build git curl ccache clang libprotobuf-c-dev protobuf-c-compiler
+    LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get install -y bison flex python-lxml libfribidi-dev swig cmake librsvg2-dev colordiff libpq-dev libpng-dev libjpeg-dev libgif-dev libgeos-dev libgd-dev libfreetype6-dev libfcgi-dev libcurl4-gnutls-dev libcairo2-dev libgdal-dev libproj-dev libxml2-dev libxslt1-dev python-dev php-dev libexempi-dev lcov lftp libgdal-dev ninja-build git curl ccache clang libprotobuf-c-dev protobuf-c-compiler libharfbuzz-dev
 
 RUN curl -L "https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64" > /usr/bin/gosu && \
     chmod a+x /usr/bin/gosu

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 MAINTAINER Camptocamp<info@camptocamp.com>
 
 RUN apt-get -y update && \
-    LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get install -y bison flex python-lxml libfribidi-dev swig cmake librsvg2-dev colordiff libpq-dev libpng-dev libjpeg-dev libgif-dev libgeos-dev libgd2-xpm-dev libfreetype6-dev libfcgi-dev libcurl4-gnutls-dev libcairo2-dev libgdal-dev libproj-dev libxml2-dev libxslt1-dev python-dev php-dev libexempi-dev lcov lftp libgdal-dev ninja-build git curl ccache clang libprotobuf-c-dev protobuf-c-compiler
+    LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get install -y bison flex python-lxml libfribidi-dev swig cmake librsvg2-dev colordiff libpq-dev libpng-dev libjpeg-dev libgif-dev libgeos-dev libgd-dev libfreetype6-dev libfcgi-dev libcurl4-gnutls-dev libcairo2-dev libgdal-dev libproj-dev libxml2-dev libxslt1-dev python-dev php-dev libexempi-dev lcov lftp libgdal-dev ninja-build git curl ccache clang libprotobuf-c-dev protobuf-c-compiler
 
 RUN curl -L "https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64" > /usr/bin/gosu && \
     chmod a+x /usr/bin/gosu

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -1,17 +1,6 @@
 #!/bin/bash
 set -e
 
-if ! [ -d /build/harfbuzz ]
-then
-    cd /build
-    curl -L http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-0.9.38.tar.bz2 | tar xjf -
-    mv harfbuzz* harfbuzz
-fi
-
-cd /build/harfbuzz
-./configure --without-cairo --without-glib --without-icu --prefix=/usr/local
-make -j4 install
-
 cd /build
 
 export CXX="/usr/lib/ccache/clang++"


### PR DESCRIPTION
libgd2-xpm-dev doesn't exist in 18.04, see:
https://packages.ubuntu.com/search?suite=artful&searchon=names&keywords=libgd2-xpm-dev

libgd2-xpm-dev is a virtual package provided by libgd-dev