### PR TITLE
Bind apache2 to port 80 for any user

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ to tune it:
 * MS_ERRORFILE: If you want the debug to something other than STDOUT
 * MAX_REQUESTS_PER_PROCESS: To work around memory leaks (defaults to 1000)
 * MAPSERVER_CATCH_SEGV: Set to 1 to have the stacktraces in case of crash
+* LISTEN_PORT_80: When running the container as an unprivileged user, apache 
+will listen to port 8080 instead of 80. Set to 1 force listening to port 80
+instead.
 
 ## Project version
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -32,6 +32,11 @@ RUN apt-get update && \
     chmod a+rx /bin/confd  && \
     mkdir --parent /etc/confd/conf.d /etc/confd/templates /etc/mapserver /docker-entrypoint.d
 
+# Allow apache2 to bind to port <1024 for any user
+RUN apt-get update && apt-get install -y libcap2-bin && setcap cap_net_bind_service=+ep /usr/sbin/apache2 && \
+    rm -rf /var/lib/apt/lists/* &&\
+    apt-get purge -y libcap2-bin
+
 EXPOSE 80
 
 COPY runtime /

--- a/server/runtime/usr/local/bin/start-server
+++ b/server/runtime/usr/local/bin/start-server
@@ -4,7 +4,7 @@ set -e
 # Save the environment to be able to restore it in the FCGI daemon (used in /usr/local/bin/mapserv_wrapper)
 env | sed -e 's/.\+/export "\0"/' > /tmp/init_env
 
-if [[ "${UID}" != 0 ]]
+if [ "${UID}" != 0 ] && [ "${LISTEN_PORT_80}" != 1 ]
 then
     echo "Switching listen port to 8080"
     cd /tmp


### PR DESCRIPTION
Because port switching to 8080 when UID != 0 is really confusing, this patch allow apache2 to bind on port 80 even for unprivileged user.

This change is also required to make the container run behind [jwilder/nginx-proxy](https://github.com/jwilder/nginx-proxy) with an unprivileged user (nginx-proxy use 80 exposed port automatically, it doesn't proxy services from 8080).