### PR TITLE
Added fcgi timeout configuration override.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ to tune it:
 * LISTEN_PORT_80: When running the container as an unprivileged user, apache 
 will listen to port 8080 instead of 80. Set to 1 force listening to port 80
 instead.
+* BUSY_TIMEOUT: The maximum time limit for request handling (defaults to 300)
+* IDLE_TIMEOUT: Application processes which have not handled a request for
+this period of time will be terminated (defaults to 300)
+* IO_TIMEOUT: The maximum period of time the module will wait while trying to
+read from or write to a FastCGI application (defaults to 40)
+
 
 ## Project version
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -47,7 +47,10 @@ ENV MS_DEBUGLEVEL=0 \
     MS_ERRORFILE=/var/log/mapserver.log \
     MAX_REQUESTS_PER_PROCESS=1000 \
     MIN_PROCESSES=1 \
-    MAX_PROCESSES=5
+    MAX_PROCESSES=5 \
+    BUSY_TIMEOUT=300 \
+    IDLE_TIMEOUT=300 \
+    IO_TIMEOUT=40
 
 RUN adduser www-data root && \
     chmod -R g+w ${APACHE_CONFDIR} ${APACHE_RUN_DIR} ${APACHE_LOCK_DIR} ${APACHE_LOG_DIR} /etc/confd /etc/mapserver /var/lib/apache2/fcgid /var/log && \

--- a/server/runtime/etc/apache2/conf-enabled/mapserver.conf
+++ b/server/runtime/etc/apache2/conf-enabled/mapserver.conf
@@ -2,6 +2,9 @@
 FcgidMaxRequestsPerProcess ${MAX_REQUESTS_PER_PROCESS}
 FcgidMinProcessesPerClass ${MIN_PROCESSES}
 FcgidMaxProcessesPerClass ${MAX_PROCESSES}
+FcgidBusyTimeout ${BUSY_TIMEOUT}
+FcgidIdleTimeout ${IDLE_TIMEOUT}
+FcgidIOTimeout ${IO_TIMEOUT}
 
 ScriptAliasMatch "^/.*" /usr/local/bin/mapserv_wrapper
 <Location />


### PR DESCRIPTION
To be able to solve "mod_fcgid: read data timeout in 40 seconds" errors when working with data on object storage.