### PR TITLE
Be able to install font with a config image as non root user

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ to tune it:
 will listen to port 8080 instead of 80. Set to 1 force listening to port 80
 instead.
 
+Fonts present in the `/etc/mapserver/fonts` directory will be installed and thus usable by mapserver.
+
 ## Project version
 
 The version 7.0.x will be in the [branch 7.0](https://github.com/camptocamp/docker-mapserver/tree/7.0).
 The version 7.2.x will be in the [branch 7.2](https://github.com/camptocamp/docker-mapserver/tree/7.2).
+The version 7.4.x will be in the [branch 7.4](https://github.com/camptocamp/docker-mapserver/tree/7.4).

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -33,6 +33,9 @@ RUN apt-get update && \
     chmod a+rx /bin/confd  && \
     mkdir --parent /etc/confd/conf.d /etc/confd/templates /etc/mapserver /docker-entrypoint.d
 
+# Be able to install font as nonroot
+RUN chmod u+s /usr/bin/fc-cache
+
 # Allow apache2 to bind to port <1024 for any user
 RUN apt-get update && apt-get install -y libcap2-bin && setcap cap_net_bind_service=+ep /usr/sbin/apache2 && \
     rm -rf /var/lib/apt/lists/* &&\

--- a/server/runtime/etc/fonts/local.conf
+++ b/server/runtime/etc/fonts/local.conf
@@ -1,0 +1,3 @@
+<fontconfig>
+  <dir>/etc/mapserver/fonts</dir>
+</fontconfig>

--- a/server/runtime/usr/local/bin/start-server
+++ b/server/runtime/usr/local/bin/start-server
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -e
 
+# Be able to install fonts without creating a new image
+if [ -e /etc/mapserver/fonts/ ]
+then
+    fc-cache --really-force --system-only
+fi
+
 # Save the environment to be able to restore it in the FCGI daemon (used in /usr/local/bin/mapserv_wrapper)
 env | sed -e 's/.\+/export "\0"/' > /tmp/init_env
 


### PR DESCRIPTION
Backport https://github.com/camptocamp/docker-qgis-server/pull/18/ and https://github.com/camptocamp/docker-qgis-server/commit/2795cf5835c399eda7eccf0c8e568b903f8013e0