### PR TITLE
Dockerfile: add support for optional build against OracleSpatial client library

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 *
 !checkout_release
 !runtime
+!instantclient

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 DOCKER_TAG ?= latest
 export DOCKER_TAG
 MAPSERVER_BRANCH ?= master
+WITH_ORACLE ?= OFF
 DOCKER_IMAGE = camptocamp/mapserver
 ROOT = $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 GID = $(shell id -g)
@@ -30,7 +31,7 @@ pull:
 
 .PHONY: build
 build:
-	docker build --tag=$(DOCKER_IMAGE):$(DOCKER_TAG) --target=runner --build-arg=MAPSERVER_BRANCH=$(MAPSERVER_BRANCH) .
+	docker build --tag=$(DOCKER_IMAGE):$(DOCKER_TAG) --target=runner --build-arg=MAPSERVER_BRANCH=$(MAPSERVER_BRANCH) --build-arg=WITH_ORACLE=$(WITH_ORACLE) .
 
 .PHONY: acceptance
 acceptance: build

--- a/instantclient/README.md
+++ b/instantclient/README.md
@@ -1,0 +1,6 @@
+Place here
+instantclient-sdk-linux.x64-19.8.0.0.0dbru.zip
+and
+instantclient-basic-linux.x64-19.8.0.0.0dbru.zip
+downloaded from
+https://www.oracle.com/database/technologies/instant-client/linux-x86-64-downloads.html


### PR DESCRIPTION
Procedure:
1. Download instantclient-basic-linux.x64-19.8.0.0.0dbru.zip and
   instantclient-sdk-linux.x64-19.8.0.0.0dbru.zip from
   https://www.oracle.com/database/technologies/instant-client/linux-x86-64-downloads.html
   and put there under the instantclient/ directory

2. "make build WITH_ORACLE=ON"

If there's interest, I've the backport of this for the 7.6 branch