### PR TITLE
start-server: run apache2 under exec so that 'docker stop' SIGTERM signal is well propagated

### DIFF
--- a/runtime/usr/local/bin/start-server
+++ b/runtime/usr/local/bin/start-server
@@ -16,4 +16,4 @@ trap '' WINCH
 
 rm -f $APACHE_RUN_DIR/apache2.pid
 
-apache2 -DFOREGROUND
+exec apache2 -DFOREGROUND


### PR DESCRIPTION
Currently 'docker stop' on a container stalls for the timeout period, because
SIGTERM is stop in the start-server shell script, and not prapagated to
apache2.
See https://hynek.me/articles/docker-signals for background