### PR TITLE
Permit access to api templates

### DIFF
--- a/runtime/etc/apache2/conf-enabled/mapserver.conf
+++ b/runtime/etc/apache2/conf-enabled/mapserver.conf
@@ -6,7 +6,7 @@ FcgidBusyTimeout ${BUSY_TIMEOUT}
 FcgidIdleTimeout ${IDLE_TIMEOUT}
 FcgidIOTimeout ${IO_TIMEOUT}
 
-ScriptAliasMatch "^/.*" /usr/local/bin/mapserv_wrapper
+ScriptAliasMatch "^/(.*)" /usr/local/bin/mapserv_wrapper/$1
 <LocationMatch "^/.*">
   # Enable CORS (required for WFS requests)
   Header set Access-Control-Allow-Origin "*"


### PR DESCRIPTION
Thanks @sbrunner for enabling ogc api!

OGC api templates are not accessible through embeded Apache because everything after root url `/` is redirected to mapserv_wrapper losing any supplementary path. See #252