### PR TITLE
GEO-6233: fix non root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,13 +98,16 @@ RUN --mount=type=cache,target=/var/cache,sharing=locked \
 RUN a2enmod fcgid headers status \
     && a2dismod -f auth_basic authn_file authn_core authz_user autoindex dir \
     && rm /etc/apache2/mods-enabled/alias.conf \
-    && mkdir --parent ${APACHE_RUN_DIR} ${APACHE_LOCK_DIR} ${APACHE_LOG_DIR} /etc/mapserver \
+    && mkdir -m 777 --parent ${APACHE_RUN_DIR} ${APACHE_LOCK_DIR} ${APACHE_LOG_DIR} /etc/mapserver /mod_fcgid \
     && find "$APACHE_CONFDIR" -type f -exec sed -ri ' \
     s!^(\s*CustomLog)\s+\S+!\1 /proc/self/fd/1!g; \
     s!^(\s*ErrorLog)\s+\S+!\1 /proc/self/fd/2!g; \
     ' '{}' ';' \
     && sed -ri 's!LogFormat "(.*)" combined!LogFormat "%{us}T %{X-Request-Id}i \1" combined!g' /etc/apache2/apache2.conf \
     && echo 'ErrorLogFormat "%{X-Request-Id}i [%l] [pid %P] %M"' >> /etc/apache2/apache2.conf \
+    && sed -i -e 's/<VirtualHost \*:80>/<VirtualHost *:8080>/' /etc/apache2/sites-available/000-default.conf \
+    && sed -i -e 's/Listen 80$/Listen 8080/' /etc/apache2/ports.conf \
+
     && mkdir --parent /etc/mapserver
 
 EXPOSE 8080
@@ -129,9 +132,8 @@ ENV MS_DEBUGLEVEL=0 \
     IO_TIMEOUT=40 \
     GET_ENV=env
 
-RUN adduser www-data root \
-    && chmod -R g+w ${APACHE_CONFDIR} ${APACHE_RUN_DIR} ${APACHE_LOCK_DIR} ${APACHE_LOG_DIR} /etc/mapserver /var/lib/apache2/fcgid /var/log \
-    && chgrp -R root ${APACHE_LOG_DIR} /var/lib/apache2/fcgid
+RUN adduser www-data root
+VOLUME /mod_fcgid
 
 CMD ["/usr/local/bin/start-server"]
 

--- a/runtime/etc/apache2/conf-enabled/mapserver.conf
+++ b/runtime/etc/apache2/conf-enabled/mapserver.conf
@@ -5,6 +5,8 @@ FcgidMaxProcessesPerClass ${MAX_PROCESSES}
 FcgidBusyTimeout ${BUSY_TIMEOUT}
 FcgidIdleTimeout ${IDLE_TIMEOUT}
 FcgidIOTimeout ${IO_TIMEOUT}
+FcgidIPCDir /mod_fcgid
+FcgidProcessTableFile /mod_fcgid/fcgid_shm
 
 ScriptAliasMatch "^/.*" /usr/local/bin/mapserv_wrapper
 <LocationMatch "^/.*">

--- a/runtime/usr/local/bin/start-server
+++ b/runtime/usr/local/bin/start-server
@@ -7,11 +7,11 @@ ${GET_ENV} | sed -e 's/^\([^=]*\)=.*/PassEnv \1/' > /tmp/pass-env
 # Save the environment to be able to restore it in the FCGI daemon (used in /usr/local/bin/mapserv_wrapper)
 ${GET_ENV} | sed -e 's/.\+/export "\0"/' > /tmp/init_env
 
-if [ "${UID}" != 0 ] && [ "${LISTEN_PORT_80}" != 1 ]; then
-    echo "Switching listen port to 8080"
+if [ "${UID}" == 0 ]; then
+    echo "Switching listen port to 80"
     cd /tmp
-    sed -i -e 's/<VirtualHost \*:80>/<VirtualHost *:8080>/' /etc/apache2/sites-available/000-default.conf
-    sed -i -e 's/Listen 80$/Listen 8080/' /etc/apache2/ports.conf
+    sed -i -e 's/<VirtualHost \*:8080>/<VirtualHost *:80>/' /etc/apache2/sites-available/000-default.conf
+    sed -i -e 's/Listen 8080$/Listen 80/' /etc/apache2/ports.conf
 fi
 
 trap '' WINCH


### PR DESCRIPTION
fix https://github.com/camptocamp/docker-mapserver/issues/422

this is required to run with both `uid` and `gid` as non root, for example to run on Openshift.