### PR TITLE
Remove DWITH_POINT_Z_M=1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,6 @@ RUN if test "${WITH_ORACLE}" = "ON"; then \
     -DWITH_KML=1 \
     -DWITH_SOS=1 \
     -DWITH_XMLMAPFILE=1 \
-    -DWITH_POINT_Z_M=1 \
     -DWITH_CAIRO=1 \
     -DWITH_RSVG=1 \
     -DUSE_PROJ=1 \


### PR DESCRIPTION
Minor change to remove the now redundant `DWITH_POINT_Z_M=1`

This option was removed in https://github.com/MapServer/MapServer/pull/6263 and was part of the 8.0 release. 