### PR TITLE
Add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Force LF (Unix) line endings for all text files
+* text=auto eol=lf


### PR DESCRIPTION
As noted in #667 building on Windows or using the WSL having checked out https://github.com/camptocamp/docker-mapserver/ with default Windows line endings results in failed builds with a cryptic error message. Adding `.gitattributes` and forcing LF fixes this. 

Enforcing Linux line-endings fixes this. 

Build command:
```
docker build  --target=runner --build-arg=MAPSERVER_BRANCH=rel-8-0-2
```

Error:

```
 => [builder 2/9] RUN git clone https://github.com/mapserver/mapserver --branch=rel-8-0-2 --depth=100 /src                                                                                                  4.6s
 => [builder 3/9] COPY checkout_release /tmp                                                                                                                                                                0.1s
 => ERROR [builder 4/9] RUN cd /src     && /tmp/checkout_release rel-8-0-2                                                                                                                                  0.6s
------
 > [builder 4/9] RUN cd /src     && /tmp/checkout_release rel-8-0-2:
0.554 + cd /src
0.555 + /tmp/checkout_release rel-8-0-2
: invalid option -
```