### PR TITLE
Fix proj-data path for Ubuntu 26.04 (#1601)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,6 +122,9 @@ COPY runtime /
 # Oracle expects libaio.so.1
 RUN if test -f /usr/lib/x86_64-linux-gnu/libaio.so.1t64; then ln -s libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1; fi
 
+# proj-data is at /usr/share/proj, but some configs expect /usr/local/share/proj
+RUN ln -s /usr/share/proj /usr/local/share/proj
+
 RUN ldconfig
 
 ENV MS_DEBUGLEVEL=0 \


### PR DESCRIPTION
Add symlink /usr/share/proj -> /usr/local/share/proj so proj-data is found at both paths.

Fixes #1601

<!-- pull request links -->
See JIRA issue: [DATA-1601](https://camptocamp.atlassian.net/browse/DATA-1601).