### PR TITLE
Rename deprecated Renovate matchFiles option to matchFileNames

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -34,7 +34,7 @@
       versioning: 'loose',
     },
     {
-      matchFiles: ['acceptance_tests/Dockerfile'],
+      matchFileNames: ['acceptance_tests/Dockerfile'],
       matchDatasources: ['docker'],
       versioning: 'ubuntu',
     },


### PR DESCRIPTION
## Summary
Rename the deprecated Renovate `matchFiles` option to `matchFileNames` in `.github/renovate.json5`.

## Context
- Renovate deprecated the `matchFiles` option, replaced by `matchFileNames`.

## Implementation Details
- Rename the option key in the affected package rule; no other change.

## Impact/Risks
- No behavior change, the rule keeps the same meaning; the preset pins are not touched.

<!-- pull request links -->
See JIRA issue: [GSGMF-2207](https://camptocamp.atlassian.net/browse/GSGMF-2207).

[GSGMF-2207]: https://camptocamp.atlassian.net/browse/GSGMF-2207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ